### PR TITLE
JBS-82: Handling of Authorization and Response

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,9 +23,9 @@ The services afterwards can be started as binaries:
 
 ::
 
- /usr/bin/ec2-api
- /usr/bin/ec2-api-metadata
- /usr/bin/ec2-api-s3
+ /usr/bin/cinder-ec2-api
+ /usr/bin/cinder-ec2-api-metadata
+ /usr/bin/cinder-ec2-api-s3
 
 or set up as Linux services.
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -36,7 +36,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = 'ec2-api'
+project = 'cinder-ec2-api'
 copyright = '2015, OpenStack Foundation'
 
 # If true, '()' will be appended to :func: etc. cross-reference text.

--- a/ec2api/api/apirequest.py
+++ b/ec2api/api/apirequest.py
@@ -99,9 +99,9 @@ class APIRequest(object):
         response_el = xml.createElement(self.action + 'Response')
         response_el.setAttribute('xmlns',
                                  'http://compute.jiocloudservices.com/doc/2016-03-01/')
-        #request_id_el = xml.createElement('requestId')
-        #request_id_el.appendChild(xml.createTextNode(request_id))
-        #response_el.appendChild(request_id_el)
+        request_id_el = xml.createElement('requestId')
+        request_id_el.appendChild(xml.createTextNode(request_id))
+        response_el.appendChild(request_id_el)
         if response_data is True:
             self._render_dict(xml, response_el, {'return': 'true'})
         else:

--- a/ec2api/api/faults.py
+++ b/ec2api/api/faults.py
@@ -81,13 +81,13 @@ class Fault(webob.exc.HTTPException):
         if status == 501:
             message = "The requested function is not supported"
 
-        if 'AWSAccessKeyId' not in req.params:
-            raise webob.exc.HTTPBadRequest()
-        user_id, _sep, project_id = req.params['AWSAccessKeyId'].partition(':')
-        project_id = project_id or user_id
-        remote_address = getattr(req, 'remote_address', '127.0.0.1')
-        if CONF.use_forwarded_for:
-            remote_address = req.headers.get('X-Forwarded-For', remote_address)
+#        if 'AWSAccessKeyId' not in req.params:
+#            raise webob.exc.HTTPBadRequest()
+#        user_id, _sep, project_id = req.params['AWSAccessKeyId'].partition(':')
+#        project_id = project_id or user_id
+#        remote_address = getattr(req, 'remote_address', '127.0.0.1')
+#        if CONF.use_forwarded_for:
+#            remote_address = req.headers.get('X-Forwarded-For', remote_address)
 
         resp = ec2_error_response(context.generate_request_id(), code,
                                   message=message, status=status)

--- a/ec2api/i18n.py
+++ b/ec2api/i18n.py
@@ -20,7 +20,7 @@ See http://docs.openstack.org/developer/oslo.i18n/usage.html .
 
 import oslo_i18n
 
-DOMAIN = 'ec2-api'
+DOMAIN = 'cinder-ec2-api'
 
 _translators = oslo_i18n.TranslatorFactory(domain=DOMAIN)
 

--- a/ec2api/version.py
+++ b/ec2api/version.py
@@ -14,4 +14,4 @@
 
 import pbr.version
 
-version_info = pbr.version.VersionInfo('ec2-api')
+version_info = pbr.version.VersionInfo('cinder-ec2-api')

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = ec2-api
+name = cinder-ec2-api
 version = 1.0.1
 summary = OpenStack Ec2api Service
 description-file =
@@ -7,7 +7,7 @@ description-file =
 license = Apache License, Version 2.0
 author = OpenStack
 author-email = openstack-dev@lists.openstack.org
-home-page = https://launchpad.net/ec2-api
+home-page = https://launchpad.net/cinder-ec2-api
 classifier =
     Environment :: OpenStack
     Intended Audience :: Information Technology
@@ -26,10 +26,10 @@ setup-hooks =
 
 [entry_points]
 console_scripts =
-    ec2-api=ec2api.cmd.api:main
-    ec2-api-manage=ec2api.cmd.manage:main
-    ec2-api-metadata=ec2api.cmd.api_metadata:main
-    ec2-api-s3=ec2api.cmd.api_s3:main
+    cinder-ec2-api=ec2api.cmd.api:main
+    cinder-ec2-api-manage=ec2api.cmd.manage:main
+    cinder-ec2-api-metadata=ec2api.cmd.api_metadata:main
+    cinder-ec2-api-s3=ec2api.cmd.api_s3:main
 
 [build_sphinx]
 all_files = 1


### PR DESCRIPTION
Discussion with Chirag:
It has been decided to go with token authorization for now. Compute JCS API would perform AWS style authorization and receive a keystone token which in-turn would be passed to SBS. So, this commit removes AWS auth params related code and sticks to token auth params related code.