### PR TITLE
JBS-130: cinder-ec2-api runs only one worker

### DIFF
--- a/ec2api/cmd/api.py
+++ b/ec2api/cmd/api.py
@@ -32,7 +32,7 @@ def main():
     logging.setup(CONF, 'ec2api')
 
     server = service.WSGIService('ec2api', max_url_len=16384)
-    service.serve(server)
+    service.serve(server, workers=server.workers)
     service.wait()
 
 


### PR DESCRIPTION
A tremendous improvement is seen after this.