### PR TITLE
Restore Describe* API response code to 404

### DIFF
--- a/ec2api/exception.py
+++ b/ec2api/exception.py
@@ -385,11 +385,13 @@ class InvalidAMIIDNotFound(EC2NotFoundException):
 
 
 class InvalidVolumeNotFound(EC2NotFoundException):
+    code = 404
     ec2_code = 'InvalidVolume.NotFound'
     msg_fmt = _("The volume '%(id)s' does not exist.")
 
 
 class InvalidSnapshotNotFound(EC2NotFoundException):
+    code = 404
     ec2_code = 'InvalidSnapshot.NotFound'
     msg_fmt = _("Snapshot %(id)s could not be found.")
 


### PR DESCRIPTION
Fix for JBS-222 caused a change in response code of DescribeVolumes
and DescribeSnapshots API methods from 404 to 400.
Restored it to 404.

Closes-Bug: #JBS-272